### PR TITLE
Add groups option and make silent

### DIFF
--- a/rules_python_poetry/poetry.bzl
+++ b/rules_python_poetry/poetry.bzl
@@ -2,7 +2,7 @@ def _poetry_impl(ctx):
    
    cmd = ["poetry", "export"]
    
-   for group in ctx.attr.with:
+   for group in ctx.attr.groups:
       cmd.append("--with="+group)
    
    result = ctx.execute(
@@ -21,7 +21,7 @@ poetry_lock = repository_rule(
             allow_single_file = True,
             mandatory = True,
         ),
-        "with": attr.string_list(
+        "groups": attr.string_list(
             default = ["dev"],  
         )
    }

--- a/rules_python_poetry/poetry.bzl
+++ b/rules_python_poetry/poetry.bzl
@@ -1,16 +1,13 @@
 def _poetry_impl(ctx):
+   
+   cmd = ["poetry", "export"]
+   
+   for group in ctx.attr.with:
+      cmd.append("--with="+group)
+   
    result = ctx.execute(
-      [
-         "poetry",
-         "export",
-         # We also export dev here since no actual distinction for this exists
-         # in rules_python. Also, the "dev" category in the lockfile is an
-         # apparently meaningless distinction...
-         # https://github.com/python-poetry/poetry/issues/5702
-         "--dev"
-      ],
+      cmd,
       working_directory = str(ctx.path(ctx.attr.lockfile).dirname),
-      quiet = False,
    )
 
    ctx.file("requirements_lock.txt", result.stdout)
@@ -24,5 +21,8 @@ poetry_lock = repository_rule(
             allow_single_file = True,
             mandatory = True,
         ),
+        "with": attr.string_list(
+            default = ["dev"],  
+        )
    }
 )


### PR DESCRIPTION
Poetry recently fixed some issues with errors going to stdout so we can make the export command quiet again. This change also adds the option for exporting one or more additional dependency groups using the new `--with` option