### PR TITLE
Report error if poetry execution failed

### DIFF
--- a/rules_python_poetry/poetry.bzl
+++ b/rules_python_poetry/poetry.bzl
@@ -10,6 +10,10 @@ def _poetry_impl(ctx):
       working_directory = str(ctx.path(ctx.attr.lockfile).dirname),
    )
 
+   if result.return_code != 0:
+      fail("Failed to execute poetry. Error: ", result.stderr)
+
+
    ctx.file("requirements_lock.txt", result.stdout)
    ctx.file("BUILD", "")
 


### PR DESCRIPTION
If poetry fails, the rule should fail, in order to stop execution.

Otherwise, the empty requirements file is generated, and build fails later on with an obscure error.